### PR TITLE
Removed Expect: 100-continue header from the HTTP request.

### DIFF
--- a/src/main/java/net/authorize/util/HttpClient.java
+++ b/src/main/java/net/authorize/util/HttpClient.java
@@ -24,6 +24,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.protocol.HTTP;
 
 /**
@@ -68,6 +69,7 @@ public class HttpClient {
 			}
 
   		    httpPost = new HttpPost(postUrl);
+                    httpPost.getParams().setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
 		    httpPost.setHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
 		    httpPost.setEntity(new StringEntity(transaction.toNVPString()));
 		} else if (transaction instanceof net.authorize.arb.Transaction ||
@@ -76,6 +78,7 @@ public class HttpClient {
 
 			  postUrl = new URI(env.getXmlBaseUrl() + "/xml/v1/request.api");
 			  httpPost = new HttpPost(postUrl);
+                          httpPost.getParams().setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
 			  httpPost.setHeader("Content-Type", "text/xml; charset=utf-8");
 			  httpPost.setEntity(new StringEntity(transaction.toXMLString()));
 		}

--- a/src/main/java/net/authorize/util/HttpUtility.java
+++ b/src/main/java/net/authorize/util/HttpUtility.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.params.CoreProtocolPNames;
 
 /**
  * Helper methods for http calls
@@ -59,6 +60,7 @@ public final class HttpUtility {
 			  logger.debug(String.format("MerchantInfo->LoginId/TransactionKey: '%s':'%s'", request.getMerchantAuthentication().getName(), request.getMerchantAuthentication().getTransactionKey() ));
 			  logger.debug(String.format("Posting request to Url: '%s'", postUrl));
 			  httpPost = new HttpPost(postUrl);
+                          httpPost.getParams().setBooleanParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
 			  httpPost.setHeader("Content-Type", "text/xml; charset=utf-8");
 			  
 			  String xmlRequest = XmlUtility.getXml(request);


### PR DESCRIPTION
Fixed for both old and new model HttpPost calls.
Review by : Gabriel Broadwin Nongsiej