### PR TITLE
GetHostedProfilePageController should not require optional hostedProfileSettings parameter.

### DIFF
--- a/src/main/java/net/authorize/api/controller/GetHostedProfilePageController.java
+++ b/src/main/java/net/authorize/api/controller/GetHostedProfilePageController.java
@@ -17,7 +17,7 @@ public class GetHostedProfilePageController extends ApiOperationBase<GetHostedPr
 		
 		//validate required fields		
 		if ( null == request.getCustomerProfileId()) throw new NullPointerException("CustomerProfileIdcannot be null");
-		if ( null == request.getHostedProfileSettings()) throw new NullPointerException("HostedProfileSettings cannot be null");
+		// HostedProfileSettings is not a required field
 		
 		//validate not-required fields		
 		//creditCardOne.setCardCode("");


### PR DESCRIPTION
Similar to issue (#64) GetHostedProfilePageController should not require the optional hostedProfileSettings parameter.

Temporary workaround is to create a custom Controller that doesn't validate against the value.

```
    public class FixedGetHostedProfilePageController extends ApiOperationBase<GetHostedProfilePageRequest, GetHostedProfilePageResponse> {

        public FixedGetHostedProfilePageController(GetHostedProfilePageRequest apiRequest) {
            super(apiRequest);
        }
        
        @Override
        protected void validateRequest() {
            GetHostedProfilePageRequest request = this.getApiRequest();
            
            //validate required fields      
            if ( null == request.getCustomerProfileId()) throw new NullPointerException("CustomerProfileIdcannot be null");
            // if ( null == request.getHostedProfileSettings()) throw new NullPointerException("HostedProfileSettings cannot be null");
            
            //validate not-required fields      
            //creditCardOne.setCardCode("");
        }

        @Override
        protected Class<GetHostedProfilePageResponse> getResponseType() {
            return GetHostedProfilePageResponse.class;
        }
    }
```
