### PR TITLE
successful transaction occurred yet no transaction response or error response due to xml exception

### DIFF
--- a/src/main/java/net/authorize/util/HttpUtility.java
+++ b/src/main/java/net/authorize/util/HttpUtility.java
@@ -8,6 +8,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,6 +27,9 @@ import org.apache.http.protocol.HTTP;
 import net.authorize.Environment;
 import net.authorize.api.contract.v1.ANetApiRequest;
 import net.authorize.api.contract.v1.ANetApiResponse;
+import net.authorize.api.contract.v1.MessageTypeEnum;
+import net.authorize.api.contract.v1.MessagesType;
+import net.authorize.api.contract.v1.MessagesType.Message;
 
 /**
  * Helper methods for http calls
@@ -107,12 +111,41 @@ public final class HttpUtility {
         	logger.debug(String.format("Response: '%s'", response));
 		} catch (InterruptedException ie) {
 			logger.error(String.format("Http call interrupted Message: '%s'", ie.getMessage()));
+			response = createErrorResponse(ie);
 		} catch (ExecutionException ee) {
 			logger.error(String.format("Execution error for http post Message: '%s'", ee.getMessage()));
+			response = createErrorResponse(ee);
 		}
 
         return response;
 	}
+
+    private static ANetApiResponse createErrorResponse(Exception exception) {
+        ANetApiResponse response = new ANetApiResponse();
+
+        MessagesType aMessage = new MessagesType();
+        aMessage.setResultCode(MessageTypeEnum.ERROR);
+        response.setMessages(aMessage);
+
+        List<Message> messages = response.getMessages().getMessage();
+        //clear all messages
+        messages.clear();
+
+        if ( null != exception) {
+            Message errorMessage = new Message();
+            messages.add(errorMessage);
+            String code = "Error";
+            String text = "Unknown Error";
+            code = exception.getClass().getCanonicalName();
+            //code = exception.getClass().getTypeName();// requires java1.8
+            text = exception.getMessage();
+
+            errorMessage.setCode(code);
+            errorMessage.setText(text);
+        }
+
+        return response;
+    }
 
 	/**
 	 * Converts a response inputstream into a string.


### PR DESCRIPTION
This transaction went through (see the Raw Response in the log) but due to an xml error, the sdk did not return a valid response.   It would be much better if there was some kind of indicator if there's any way that processing a valid raw response throws an exception.  Perhaps by locally constructing a valid ANetApiResponse indicating that an error has occurred during response processing so that we know we need to go investigate what was actually processed.

Note:  I am still investigating the specific exception thrown, but that is a separate issue than general response parsing exception handling.

`Ebpp DEBUG [pool-2-thread-1 04-19 15:20:01] HttpCallTask: Raw Response: '<?xml version="1.0" encoding="utf-8"?><createTransactionResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd"><messages><resultCode>Ok</resultCode><message><code>I00001</code><text>Successful.</text></message></messages><transactionResponse><responseCode>1</responseCode><authCode>3ILLXT</authCode><avsResultCode>Y</avsResultCode><cvvResultCode>P</cvvResultCode><cavvResultCode>2</cavvResultCode><transId>2256357095</transId><refTransID /><transHash>DD83046093AB8B272FE5E9408B1CAF8D</transHash><testRequest>0</testRequest><accountNumber>XXXX8888</accountNumber><entryMode>Keyed</entryMode><accountType>Visa</accountType><messages><message><code>1</code><description>This transaction has been approved.</description></message></messages></transactionResponse></createTransactionResponse>
'
Apr 19, 2016 3:20:02 PM com.sun.xml.internal.bind.v2.util.XmlFactory createParserFactory
SEVERE: null
org.xml.sax.SAXNotRecognizedException: Feature 'http://javax.xml.XMLConstants/feature/secure-processing' is not recognized.
    at org.apache.xerces.parsers.AbstractSAXParser.setFeature(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserImpl.setFeatures(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserImpl.<init>(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserFactoryImpl.newSAXParserImpl(Unknown Source)
    at org.apache.xerces.jaxp.SAXParserFactoryImpl.setFeature(Unknown Source)
    at com.sun.xml.internal.bind.v2.util.XmlFactory.createParserFactory(XmlFactory.java:121)
    at com.sun.xml.internal.bind.v2.runtime.unmarshaller.UnmarshallerImpl.getXMLReader(UnmarshallerImpl.java:139)
    at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:157)
    at javax.xml.bind.helpers.AbstractUnmarshallerImpl.unmarshal(AbstractUnmarshallerImpl.java:214)
    at net.authorize.util.XmlUtility.create(XmlUtility.java:78)
    at net.authorize.util.HttpCallTask.call(HttpCallTask.java:93)
    at net.authorize.util.HttpCallTask.call(HttpCallTask.java:32)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)

Ebpp ERROR [112302969@qtp0-0 04-19 15:20:02] HttpUtility: Execution error for http post Message: 'java.lang.IllegalStateException: org.xml.sax.SAXNotRecognizedException: Feature 'http://javax.xml.XMLConstants/feature/secure-processing' is not recognized.'
Ebpp DEBUG [112302969@qtp0-0 04-19 15:20:02] ApiOperationBase: Got a 'null' Response for request:'net.authorize.api.contract.v1.CreateTransactionRequest@666d32c7'
`
