### PR TITLE
Log4j issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,12 +58,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.16</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jmock</groupId>
             <artifactId>jmock</artifactId>
             <version>2.6.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,9 @@
                 <includes>
                     <include>*</include>
                 </includes>
+                <excludes>
+                    <exclude>**/log4j.properties</exclude>
+                </excludes>
             </resource>
         </resources>
     </build>


### PR DESCRIPTION
We started deploying versions of our application to tomcat today.   One thing I noticed is that our logging disappeared.

Investigation showed that the anet-java-sdk-1.8.9-SNAPSHOT.jar contains a WEB-INF/classes/log4j.properties file that overrode our logging configuration.  Updating to 1.9.1-snapshot today still shows the same problem.

This looks to be a bug in the maven build as the ant build does not include the contents of resources/.

I did a search through the java sdk source code, and I see nothing that directly references log4j despite the README.md and pom.xml's statement that log4j is a compile dependency.  Removing the log4j dependency from the pom.xml altogether did not affect the build process.

I would also recommend that you remove the log4j dependency or change it to indicate that it is optional since it is not needed to compile or use the sdk.   I'm guessing it may only needed for logging while running the tests.

I also noticed that there were several differences, at first glance test-related, between the contents of the ant and maven jars.

I recommend that you compare the two jar builds to insure that they contain the same files -- eclipse allows you to compare two jar files easily by selecting each jar and choosing "compare with each other"

I've submitted this as a pull request only to provide an example of what I did.
