### PR TITLE
Removing validation for customerProfileId in GetCustomerProfileController

### DIFF
--- a/src/main/java/net/authorize/api/controller/GetCustomerProfileController.java
+++ b/src/main/java/net/authorize/api/controller/GetCustomerProfileController.java
@@ -16,8 +16,7 @@ public class GetCustomerProfileController extends ApiOperationBase<GetCustomerPr
 		GetCustomerProfileRequest request = this.getApiRequest();
 		
 		//validate required fields		
-		if ( null == request.getCustomerProfileId()) throw new NullPointerException("CustomerProfileId cannot be null");
-		
+
 		//validate not-required fields		
 		//creditCardOne.setCardCode("");
 	}


### PR DESCRIPTION
Removing validation for customerProfileId as it is no longer required.  This validation causes an exception when trying to get customer profile by merchant customer id (or email).  See documentation here: https://developer.authorize.net/api/reference/index.html#customer-profiles-get-customer-profile