### PR TITLE
ant jar build fails to include AuthorizedNetSensitiveTagsConfig.json

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -57,10 +57,16 @@
 				<include name="**/*.class" />
 				<exclude name="**/*Test*.class" />
 			</fileset>
+			<fileset dir="${resources.dir}">
+				<include name="**/AuthorizedNetSensitiveTagsConfig.json" />
+			</fileset>
 		</jar>
 		<jar jarfile="${build.dir}/${ant.project.name}-test-${version}.jar">
 			<fileset dir="${classes.dir}">
 				<include name="**/*Test*.class" />
+			</fileset>
+			<fileset dir="${resources.dir}">
+				<include name="**/AuthorizedNetSensitiveTagsConfig.json" />
 			</fileset>
 		</jar>
 


### PR DESCRIPTION
The ant jar build task doesn't include resources/AuthorizedNetSensitiveTagsConfig.json