### PR TITLE
Support separate logger for sensitive information (take 2)

### DIFF
--- a/src/main/java/net/authorize/util/SensitiveFilterLogWrapper.java
+++ b/src/main/java/net/authorize/util/SensitiveFilterLogWrapper.java
@@ -1,0 +1,178 @@
+package net.authorize.util;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class SensitiveFilterLogWrapper implements Log {
+
+    private static final String SENSITIVE_CONFIG_FILE_NAME = "/AuthorizedNetSensitiveTagsConfig.json";
+
+    private static Pattern[] cardPatterns;
+
+    private static Pattern[] tagPatterns;
+    private static String[] tagReplacements;
+    private static Gson gson;
+    private Log delegate;
+
+    public SensitiveFilterLogWrapper(Log delegate) {
+        this.delegate = delegate;
+
+        parseConfiguration(delegate);
+    }
+
+    private void parseConfiguration(Log delegate) {
+        try {
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            gsonBuilder.registerTypeAdapter(SensitiveDataConfigType.class, new SensitiveTagsDeserializer());
+            gson = gsonBuilder.create();
+
+            InputStream in = getClass().getResourceAsStream(SENSITIVE_CONFIG_FILE_NAME);
+            Closeable closeableResource = in;
+            if (null != in) {
+                try {
+                    InputStreamReader inputStreamReader = new InputStreamReader(in);
+                    closeableResource = inputStreamReader;
+                    BufferedReader reader = new BufferedReader(inputStreamReader);
+                    closeableResource = reader;
+                    SensitiveDataConfigType configType = gson.fromJson(reader, SensitiveDataConfigType.class);
+                    cardPatterns = new Pattern[configType.sensitiveStringRegexes.length];
+
+                    for (int i = 0; i < configType.sensitiveStringRegexes.length; i++) {
+                        cardPatterns[i] = Pattern.compile(configType.sensitiveStringRegexes[i]);
+                    }
+
+                    int noOfSensitiveTags = configType.sensitiveTags.length;
+                    tagPatterns = new Pattern[noOfSensitiveTags];
+                    tagReplacements = new String[noOfSensitiveTags];
+
+                    for (int j = 0; j < noOfSensitiveTags; j++) {
+                        String tagName = configType.sensitiveTags[j].tagName;
+                        String pattern = configType.sensitiveTags[j].pattern;
+                        String replacement = configType.sensitiveTags[j].replacement;
+
+                        if (pattern != null && !pattern.isEmpty())
+                            tagPatterns[j] = Pattern.compile("<" + tagName + ">" + pattern + "</" + tagName + ">");
+                        else
+                            tagPatterns[j] = Pattern.compile("<" + tagName + ">" + ".+" + "</" + tagName + ">");
+                        tagReplacements[j] = "<" + tagName + ">" + replacement + "</" + tagName + ">";
+                    }
+                } finally {
+                    closeableResource.close();
+                }
+            } else {
+                delegate.error("Resource " + SENSITIVE_CONFIG_FILE_NAME + " not found when configuring SensitiveFilterLogWrapper");
+            }
+        } catch (Exception e) {
+            delegate.error("Something went wrong configuring the SensitiveFilterLogWrapper", e);
+        }
+    }
+
+    public static String maskCreditCards(String str) {
+        for (int i = 0; i < cardPatterns.length; i++) {
+            str = cardPatterns[i].matcher(str).replaceAll("XXXX");
+        }
+        return str;
+    }
+
+    public static String maskSensitiveXmlString(String str) {
+        for (int i = 0; i < tagPatterns.length; i++) {
+            str = tagPatterns[i].matcher(str).replaceAll(tagReplacements[i]);
+        }
+        return str;
+    }
+
+    public String filterSensitiveInformation(Object messageObject) {
+        if (null == messageObject) {
+            return null;
+        }
+
+        String message = messageObject.toString();
+        try {
+            String messageWithMaskedXml = SensitiveFilterLogWrapper.maskSensitiveXmlString(message);
+            String messageWithMaskedCardNumber = SensitiveFilterLogWrapper.maskCreditCards(messageWithMaskedXml);
+            return messageWithMaskedCardNumber;
+        } catch (Exception e) {
+            return "Error masking message: " + e.getMessage();
+        }
+    }
+
+    public void debug(Object arg0, Throwable arg1) {
+        delegate.debug(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void debug(Object arg0) {
+        delegate.debug(filterSensitiveInformation(arg0));
+    }
+
+    public void error(Object arg0, Throwable arg1) {
+        delegate.error(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void error(Object arg0) {
+        delegate.error(filterSensitiveInformation(arg0));
+    }
+
+    public void fatal(Object arg0, Throwable arg1) {
+        delegate.fatal(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void fatal(Object arg0) {
+        delegate.fatal(filterSensitiveInformation(arg0));
+    }
+
+    public void info(Object arg0, Throwable arg1) {
+        delegate.info(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void info(Object arg0) {
+        delegate.info(filterSensitiveInformation(arg0));
+    }
+
+    public boolean isDebugEnabled() {
+        return delegate.isDebugEnabled();
+    }
+
+    public boolean isErrorEnabled() {
+        return delegate.isErrorEnabled();
+    }
+
+    public boolean isFatalEnabled() {
+        return delegate.isFatalEnabled();
+    }
+
+    public boolean isInfoEnabled() {
+        return delegate.isInfoEnabled();
+    }
+
+    public boolean isTraceEnabled() {
+        return delegate.isTraceEnabled();
+    }
+
+    public boolean isWarnEnabled() {
+        return delegate.isWarnEnabled();
+    }
+
+    public void trace(Object arg0, Throwable arg1) {
+        delegate.trace(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void trace(Object arg0) {
+        delegate.trace(filterSensitiveInformation(arg0));
+    }
+
+    public void warn(Object arg0, Throwable arg1) {
+        delegate.warn(filterSensitiveInformation(arg0), arg1);
+    }
+
+    public void warn(Object arg0) {
+        delegate.warn(filterSensitiveInformation(arg0));
+    }
+}

--- a/src/main/java/net/authorize/util/SensitiveLogger.java
+++ b/src/main/java/net/authorize/util/SensitiveLogger.java
@@ -1,0 +1,5 @@
+package net.authorize.util;
+
+public class SensitiveLogger {
+
+}


### PR DESCRIPTION
This PR takes the flexibility of PR #88 and merges it with the configurable masking provided by PR #139 without creating a hard dependency on log4j layout configuration.

This is done by replacing the SensitiveFilterLayout with a wrapped Logger class SensitiveFilterLogWrapper.  If the sensitive logger is not enabled, then we log to the filtered masked logger.

This PR doesn't change every logger reference to be filtered, but only the two most problematic classes of HttpCallTask and HttpUtility.   However, it would be a good idea to expend this to all loggers.

There's also a tradeoff between having unfiltered loggers defined for each class or having a single centralized logger.   For end-users, having a single logger makes the most sense as only one logging configuration line has to be used and end-users don't care where internally a message is being logged.   But sdk-java developers might prefer to have logging messages per class.

One possible solution to this would be to create individual loggers for each class in a single package, so only the package has to be configured.   Another would be to pick logger names manually instead of using classes, such as "net.authorize.sensitive.util.HttpCallTask" so that a single configuration line could still disable all sensitive logging, yet individual logging is also configurable and the name of the class doing the logging still appears in the logger name.

Switch from unfiltered logging of sensitive output to masked output  in this implementation by using 

log4j.logger.net.authorize.util.SensitiveLogger=OFF

