### PR TITLE
Exclude junit from compile scope (fixes #188)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-1.2-api</artifactId>
 			<version>${log4j.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 <!-- 		Log4j Dependencies -->
 		<dependency>


### PR DESCRIPTION
This PR fixes issue #188 
We exclude JUnit from the `log4j-1.2-api` so that it won't be included in the `compile` scope