### PR TITLE
Upgrade Log4j 2.16.0 to 2.17.1 to fix CVE-2021-44832 Vulnerability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Note 2: Support for higher versions of JDK (>= 1.9.0) has not been made availab
 
 ### Dependencies
 * commons-logging-1.1.1.jar : logging
-* log4j-2.16.0.jar          : logging
+* log4j-2.17.1.jar          : logging
 * httpclient-4.0.1.jar      : http communication with the payment gateway
 * httpcore-4.0.1.jar        : http communication with the payment gateway
 * junit-4.8.2.jar           : unit testing

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 		<maven.compile.target>1.5</maven.compile.target>
 		<maven.compile.optimize>true</maven.compile.optimize>
 		<maven.compile.deprecation>true</maven.compile.deprecation>
-		<log4j.version>2.16.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 	<build>
 		<plugins>


### PR DESCRIPTION
# Changes
* Change `log4j.version` property value to 2.17.1.
* Edit README.md and update the Log4j version.