### PR TITLE
Run all the tests in multiple forked VM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 						<include> **/mocktest/**.java</include>
 					</includes>
 					<skipTests>false</skipTests>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 					<systemPropertyVariables>
 						<API_LOGIN_ID>${api.login.id}</API_LOGIN_ID>
 						<TRANSACTION_KEY>${transaction.key}</TRANSACTION_KEY>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
